### PR TITLE
Add multimonitor OS for CC Tweaked

### DIFF
--- a/cc-os/chat.lua
+++ b/cc-os/chat.lua
@@ -1,0 +1,5 @@
+print("Chat placeholder - type messages")
+while true do
+  local msg = read()
+  print("You: " .. msg)
+end

--- a/cc-os/clock.lua
+++ b/cc-os/clock.lua
@@ -1,0 +1,6 @@
+while true do
+  term.setCursorPos(1,1)
+  term.clear()
+  term.write(textutils.formatTime(os.time(), true))
+  sleep(1)
+end

--- a/cc-os/levelos.lua
+++ b/cc-os/levelos.lua
@@ -1,0 +1,10 @@
+term.setBackgroundColor(colors.black)
+term.setTextColor(colors.white)
+term.clear()
+term.setCursorPos(1,1)
+print("LevelOS - Multimonitor Demo")
+print("Time: " .. textutils.formatTime(os.time(), true))
+print("Press Ctrl+T to exit")
+while true do
+  os.pullEvent()
+end

--- a/cc-os/monitor_manager.lua
+++ b/cc-os/monitor_manager.lua
@@ -1,0 +1,124 @@
+local MonitorManager = {}
+
+MonitorManager.monitors = {}
+
+local function log(msg)
+  print("[MonitorManager] " .. msg)
+end
+
+function MonitorManager.init(defaultProgram)
+  for _, name in pairs(peripheral.getNames()) do
+    if peripheral.getType(name) == "monitor" then
+      MonitorManager.monitors[name] = {
+        side = name,
+        program = defaultProgram or "levelos.lua",
+        args = {},
+        role = "default",
+      }
+      log("Found monitor on " .. name)
+    end
+  end
+end
+
+local function runProgram(side, program, args)
+  local mon = peripheral.wrap(side)
+  if not mon then return end
+  term.redirect(mon)
+  mon.setCursorPos(1,1)
+  mon.clear()
+  local ok, err = pcall(function()
+    shell.run("cc-os/" .. program, table.unpack(args or {}))
+  end)
+  term.redirect(term.native())
+  if not ok then
+    log("Error on " .. side .. ": " .. err)
+    mon.setCursorPos(1,1)
+    mon.write(err)
+  end
+end
+
+function MonitorManager.monitorLoop(side)
+  local info = MonitorManager.monitors[side]
+  while true do
+    if info.program then
+      runProgram(side, info.program, info.args)
+    end
+    local ev = os.pullEvent()
+    if ev == "monitor_update_" .. side then
+      -- continue loop to restart program
+    elseif ev == "monitor_close_" .. side then
+      break
+    end
+  end
+end
+
+function MonitorManager.start(side)
+  local info = MonitorManager.monitors[side]
+  if not info then return end
+  info.task = function() MonitorManager.monitorLoop(side) end
+end
+
+function MonitorManager.shell()
+  while true do
+    io.write("shell> ")
+    local line = read()
+    local args = {}
+    for word in string.gmatch(line, "%S+") do table.insert(args, word) end
+    local cmd = args[1]
+    if cmd == "list" then
+      for s, data in pairs(MonitorManager.monitors) do
+        print(s .. " -> " .. (data.program or "<none>") .. " (" .. (data.role or "") .. ")")
+      end
+    elseif cmd == "switch" and args[2] and args[3] then
+      local m = MonitorManager.monitors[args[2]]
+      if m then
+        m.program = args[3]
+        m.args = { table.unpack(args,4) }
+        os.queueEvent("monitor_update_"..args[2])
+      else
+        print("Unknown monitor: " .. args[2])
+      end
+    elseif cmd == "show" and args[2] and args[3] then
+      local m = MonitorManager.monitors[args[2]]
+      if m then
+        m.program = "nfp_display.lua"
+        m.args = { args[3] }
+        os.queueEvent("monitor_update_"..args[2])
+      else
+        print("Unknown monitor: " .. args[2])
+      end
+    elseif cmd == "close" and args[2] then
+      local m = MonitorManager.monitors[args[2]]
+      if m then
+        m.program = nil
+        os.queueEvent("monitor_update_"..args[2])
+      end
+    elseif cmd == "reboot" and args[2] then
+      local m = MonitorManager.monitors[args[2]]
+      if m then
+        os.queueEvent("monitor_update_"..args[2])
+      end
+    elseif cmd == "assign" and args[2] and args[3] then
+      local m = MonitorManager.monitors[args[2]]
+      if m then
+        m.role = args[3]
+      end
+    elseif cmd == "exit" then
+      break
+    elseif cmd ~= "" then
+      print("Unknown command: " .. cmd)
+    end
+  end
+end
+
+function MonitorManager.run()
+  local tasks = {}
+  for side in pairs(MonitorManager.monitors) do
+    MonitorManager.start(side)
+    table.insert(tasks, MonitorManager.monitors[side].task)
+  end
+  table.insert(tasks, MonitorManager.shell)
+  parallel.waitForAny(table.unpack(tasks))
+end
+
+return MonitorManager

--- a/cc-os/nfp_display.lua
+++ b/cc-os/nfp_display.lua
@@ -1,0 +1,19 @@
+local args = {...}
+if #args < 1 then
+  print("Usage: nfp_display <path>")
+  return
+end
+
+local path = args[1]
+local image = paintutils.loadImage(path)
+if not image then
+  error("Failed to load image: " .. path)
+end
+
+local w, h = term.getSize()
+local imgW = #image[1]
+local imgH = #image
+local startX = math.floor((w - imgW) / 2) + 1
+local startY = math.floor((h - imgH) / 2) + 1
+
+paintutils.drawImage(image, startX, startY)

--- a/cc-os/status.lua
+++ b/cc-os/status.lua
@@ -1,0 +1,6 @@
+while true do
+  term.clear()
+  term.setCursorPos(1,1)
+  print("Status OK")
+  sleep(5)
+end

--- a/startup.lua
+++ b/startup.lua
@@ -1,0 +1,4 @@
+local manager = dofile("cc-os/monitor_manager.lua")
+
+manager.init("levelos.lua")
+manager.run()


### PR DESCRIPTION
## Summary
- add startup.lua entry point
- implement monitor_manager with coroutine driven monitor tasks and shell commands
- add simple demo apps: levelos, clock, status, chat
- add nfp_display utility for showing .nfp images

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684cf4c114348326a98eeaeefa6a75ac